### PR TITLE
Ed/move loss

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -6,11 +6,6 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 
-if torch.cuda.is_available():
-    dtype = torch.cuda.FloatTensor
-else:
-    dtype = torch.FloatTensor
-
 
 class GeneExpressionDataset(Dataset):
     """Gene Expression dataset. It deals with:
@@ -37,7 +32,9 @@ class GeneExpressionDataset(Dataset):
                            torch.from_numpy(i * np.ones((X.size()[0], 1))).type(torch.FloatTensor)),
                           dim=1)]
 
-        self.X = torch.cat(new_Xs, dim=0)  # .type(dtype)
+        self.X = torch.cat(new_Xs, dim=0)
+        if torch.cuda.is_available():  # TODO: check valid
+            self.X.cuda()
         self.total_size = self.X.size(0)
 
     def get_all(self):
@@ -45,15 +42,14 @@ class GeneExpressionDataset(Dataset):
 
     def get_batches(self):
         dtype = torch.cuda.IntTensor if torch.cuda.is_available() else torch.IntTensor
-        return self.X[:, -1].type(dtype).numpy()
+        return self.X[:, -1:].type(dtype).numpy()
 
     def __len__(self):
         return self.total_size
 
     def __getitem__(self, idx):
         # Returns the triplet (X, local_mean, local_var)
-        return self.X[idx, :self.nb_genes], self.X[idx, self.nb_genes], self.X[idx, self.nb_genes + 1], \
-               self.X[idx, self.nb_genes + 2]
+        return self.X[idx, :self.nb_genes], self.X[idx, -3:-2], self.X[idx, -2:-1], self.X[idx, -1:]
 
     @staticmethod
     def train_test_split(*Xs, train_size=0.75):

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -2,7 +2,6 @@
 """Main module."""
 import collections
 
-import numpy as np
 import torch
 import torch.nn as nn
 from torch.autograd import Variable
@@ -76,8 +75,7 @@ class VAE(nn.Module):
             ((ql_m - local_l_mean) ** 2) / local_l_var + ql_v / local_l_var
             + torch.log(local_l_var + 1e-8) - torch.log(ql_v + 1e-8) - 1), dim=1)
 
-        kl_ponderation = Variable(torch.from_numpy(np.array([kl_ponderation])).type(dtype),
-                                  requires_grad=False)
+        kl_ponderation = Variable(dtype([kl_ponderation]), requires_grad=False)
         kl_divergence = (kl_divergence_z + kl_divergence_l)
 
         # Total Loss

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -15,9 +15,9 @@ def train(vae, data_loader, n_epochs=20, learning_rate=0.001, kl=None):
     # Training the model
     for epoch in range(n_epochs):
         for i_batch, (sample_batch, local_l_mean, local_l_var, batch_index) in enumerate(data_loader):
-            sample_batch = Variable(sample_batch.type(dtype), requires_grad=False)
-            local_l_mean = Variable(local_l_mean.type(dtype), requires_grad=False)
-            local_l_var = Variable(local_l_var.type(dtype), requires_grad=False)
+            sample_batch = Variable(sample_batch)
+            local_l_mean = Variable(local_l_mean)
+            local_l_var = Variable(local_l_var)
 
             if kl is None:
                 kl_ponderation = min(1, epoch / 400.)
@@ -25,7 +25,9 @@ def train(vae, data_loader, n_epochs=20, learning_rate=0.001, kl=None):
                 kl_ponderation = kl
 
             # Train loss is actually different from the real loss due to kl_ponderation
-            train_loss, reconst_loss, kl_divergence = vae.loss(sample_batch, local_l_mean, local_l_var, kl_ponderation)
+            train_loss, reconst_loss, kl_divergence = vae.loss(
+                sample_batch, local_l_mean, local_l_var, dtype([kl_ponderation])
+            )
             real_loss = reconst_loss + kl_divergence
             optimizer.zero_grad()
             train_loss.backward()

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 from torch.autograd import Variable
 
@@ -21,7 +20,7 @@ def train(vae, data_loader, n_epochs=20, learning_rate=0.001, kl=None):
             local_l_var = Variable(local_l_var.type(dtype), requires_grad=False)
 
             if kl is None:
-                kl_ponderation = np.minimum(1, epoch / 400.)
+                kl_ponderation = min(1, epoch / 400.)
             else:
                 kl_ponderation = kl
 

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -2,8 +2,6 @@ import numpy as np
 import torch
 from torch.autograd import Variable
 
-from scvi.log_likelihood import log_zinb_positive
-
 if torch.cuda.is_available():
     dtype = torch.cuda.FloatTensor
 else:
@@ -17,41 +15,26 @@ def train(vae, data_loader, n_epochs=20, learning_rate=0.001, kl=None):
 
     # Training the model
     for epoch in range(n_epochs):
-        for i_batch, (sample_batched, local_l_mean, local_l_var, batch_index) in enumerate(data_loader):
-            sample_batched = Variable(sample_batched.type(dtype), requires_grad=False)
+        for i_batch, (sample_batch, local_l_mean, local_l_var, batch_index) in enumerate(data_loader):
+            sample_batch = Variable(sample_batch.type(dtype), requires_grad=False)
             local_l_mean = Variable(local_l_mean.type(dtype), requires_grad=False)
             local_l_var = Variable(local_l_var.type(dtype), requires_grad=False)
-
-            px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = vae(sample_batched)
-
-            # Computing the reconstruction loss
-
-            reconst_loss = -log_zinb_positive(sample_batched, px_rate, torch.exp(px_r), px_dropout)
-
-            # Computing the kl divergence
-            kl_divergence_z = torch.sum(0.5 * (qz_m ** 2 + qz_v - torch.log(qz_v + 1e-8) - 1), dim=1)
-            kl_divergence_l = torch.sum(0.5 * (
-                ((ql_m - local_l_mean) ** 2) / local_l_var + ql_v / local_l_var
-                + torch.log(local_l_var + 1e-8) - torch.log(ql_v + 1e-8) - 1), dim=1)
 
             if kl is None:
                 kl_ponderation = np.minimum(1, epoch / 400.)
             else:
                 kl_ponderation = kl
 
-            kl_ponderation = Variable(torch.from_numpy(np.array([kl_ponderation])).type(dtype),
-                                      requires_grad=False)
-            kl_divergence = (kl_divergence_z + kl_divergence_l)
-
-            # Backprop + Optimize
-            total_loss = torch.mean(reconst_loss + kl_ponderation * kl_divergence)
+            # Train loss is actually different from the real loss due to kl_ponderation
+            train_loss, reconst_loss, kl_divergence = vae.loss(sample_batch, local_l_mean, local_l_var, kl_ponderation)
+            real_loss = reconst_loss + kl_divergence
             optimizer.zero_grad()
-            total_loss.backward()
+            train_loss.backward()
             optimizer.step()
 
             # Simply printing the results
             if i_batch % 100 == 0 and epoch % 1 == 0:
                 print("Epoch[%d/%d], Step [%d/%d], Total Loss: %.4f, "
                       "Reconst Loss: %.4f, KL Div: %.7f"
-                      % (epoch + 1, n_epochs, i_batch + 1, iter_per_epoch, total_loss.data[0],
+                      % (epoch + 1, n_epochs, i_batch + 1, iter_per_epoch, real_loss.data[0],
                          torch.mean(reconst_loss).data[0], torch.mean(kl_divergence).data[0]))


### PR DESCRIPTION
Resolved issues:

* Moving loss to VAE
* Don't recompute variance from scratch: resolves #30
* Set encoder/decoder parameters to match those of VAE: fixes #31
* Use register buffer for px_r (when dispersion mode is “gene”)
* Only call cuda twice (in dataset and in run_benchmarks after vat init)
* Remove requires_grad in Variable (default option)

Unresolved issues:

* dtype is not completely removed because of kl_ponderation.
* Also register_buffer creates a tensor, but it is necessary to call Variable(self.px_r) afterwards for the operations (there might be a cleaner solution ?)