### PR TITLE
option for recons loss + train test eval + remove dtype

### DIFF
--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -4,8 +4,9 @@
 """Run all the benchmarks with specific parameters"""
 import argparse
 import time
-from scvi.dataset import load_dataset
+
 from scvi.benchmark import run_benchmarks
+from scvi.dataset import load_datasets
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -17,9 +18,9 @@ if __name__ == '__main__':
     # parser.add_argument("-b", "--bool", help="a bool", action="store_true", default=False)
 
     args = parser.parse_args()
-    gene_dataset = load_dataset(args.dataset)
+    gene_dataset_train, gene_dataset_test = load_datasets(args.dataset)
     start = time.time()
-    run_benchmarks(gene_dataset, n_epochs=args.epochs)
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs)
     end = time.time()
     print("Total runtime for " + str(args.epochs) + " epochs is: " + str((end - start))
-          + " seconds for a mean per epoch runtime of " + str((end - start)/args.epochs) + " seconds.")
+          + " seconds for a mean per epoch runtime of " + str((end - start) / args.epochs) + " seconds.")

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -1,26 +1,13 @@
 import torch
-from torch.autograd import Variable
 from torch.utils.data import DataLoader
 
 from scvi.clustering import entropy_batch_mixing
 from scvi.imputation import imputation
-from scvi.log_likelihood import log_zinb_positive
 from scvi.scvi import VAE
 from scvi.train import train
 
 
-def compute_log_likelihood(vae, gene_dataset):
-    data_loader_test = DataLoader(gene_dataset, batch_size=gene_dataset.total_size, shuffle=False, num_workers=1)
-    for i_batch, (sample_batched, local_l_mean, local_l_var, batch_index) in enumerate(data_loader_test):
-        sample_batched = Variable(sample_batched)
-        px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = vae(sample_batched)
-        log_lkl = torch.mean(
-            -log_zinb_positive(sample_batched, px_rate, Variable(torch.exp(px_r)), px_dropout)
-        ).data[0]
-    return log_lkl
-
-
-def run_benchmarks(gene_dataset, n_epochs=1000, learning_rate=1e-3):
+def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learning_rate=1e-3):
     # options:
     # - gene_dataset: a GeneExpressionDataset object
     # call each of the 4 benchmarks:
@@ -31,25 +18,28 @@ def run_benchmarks(gene_dataset, n_epochs=1000, learning_rate=1e-3):
 
     torch.backends.cudnn.benchmark = True
 
-    data_loader = DataLoader(gene_dataset, batch_size=128, shuffle=True, num_workers=1)
-    vae = VAE(gene_dataset.nb_genes)
+    data_loader_train = DataLoader(gene_dataset_train, batch_size=128, shuffle=True, num_workers=1)
+    data_loader_test = DataLoader(gene_dataset_test, batch_size=128, shuffle=True, num_workers=1)
+    vae = VAE(gene_dataset_train.nb_genes)
     if torch.cuda.is_available():
         vae.cuda()
-    train(vae, data_loader, n_epochs=n_epochs, learning_rate=learning_rate)
+    train(vae, data_loader_train, data_loader_test, n_epochs=n_epochs, learning_rate=learning_rate)
 
     # - log-likelihood
-
-    log_likelihood = compute_log_likelihood(vae, gene_dataset)
-    print("Log-likelihood :", log_likelihood)
+    vae.eval()  # Test mode - affecting dropout and batchnorm
+    log_likelihood_train = vae.compute_log_likelihood(data_loader_train)
+    log_likelihood_test = vae.compute_log_likelihood(data_loader_test)
+    print("Log-likelihood Train:", log_likelihood_train)
+    print("Log-likelihood Test:", log_likelihood_test)
 
     # - imputation
 
-    imputation_score = imputation(vae, gene_dataset)
+    imputation_score = imputation(vae, gene_dataset_train)
     print("Imputation score (MAE) is:", imputation_score)
 
     # - batch mixing
-    if gene_dataset.n_batches == 2:
-        vae(gene_dataset.get_all())  # Just run a forward pass on all the data
+    if gene_dataset_train.n_batches == 2:
+        vae(gene_dataset_train.get_all())  # Just run a forward pass on all the data
         latent = vae.z.data.numpy()
-        batches = gene_dataset.get_batches()
+        batches = gene_dataset_train.get_batches()
         print("Entropy batch mixing :", entropy_batch_mixing(latent, batches))

--- a/scvi/dataset/__init__.py
+++ b/scvi/dataset/__init__.py
@@ -7,11 +7,11 @@ __all__ = ['SyntheticDataset',
            'GeneExpressionDataset']
 
 
-def load_dataset(dataset_name):
+def load_datasets(dataset_name):
     if dataset_name == 'synthetic':
-        gene_dataset = SyntheticDataset()
+        gene_dataset_train, gene_dataset_test = SyntheticDataset(), SyntheticDataset()
     elif dataset_name == 'cortex':
-        gene_dataset = CortexDataset()
+        gene_dataset_train, gene_dataset_test = CortexDataset(type="train"), CortexDataset(type="test")
     else:
         raise "No such dataset available"
-    return gene_dataset
+    return gene_dataset_train, gene_dataset_test

--- a/scvi/dataset/cortex.py
+++ b/scvi/dataset/cortex.py
@@ -8,11 +8,14 @@ from .dataset import GeneExpressionDataset
 
 
 class CortexDataset(GeneExpressionDataset):
-    def __init__(self):
+    def __init__(self, type='train'):
         # Generating samples according to a ZINB process
         self.save_path = 'data/'
         self.download_name = 'expression.bin'
-        self.final_name = 'expression_train.npy'
+        if type == 'train':
+            self.final_name = 'expression_train.npy'
+        elif type == 'test':
+            self.final_name = 'expression_test.npy'
         self.download_and_preprocess()
         super(CortexDataset, self).__init__([np.load(self.save_path + self.final_name)])
 

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -33,8 +33,6 @@ class GeneExpressionDataset(Dataset):
                           dim=1)]
 
         self.X = torch.cat(new_Xs, dim=0)
-        if torch.cuda.is_available():  # TODO: check valid
-            self.X.cuda()
         self.total_size = self.X.size(0)
 
     def get_all(self):
@@ -49,6 +47,7 @@ class GeneExpressionDataset(Dataset):
 
     def __getitem__(self, idx):
         # Returns the triplet (X, local_mean, local_var)
+        # Shouldn't we call .cuda here ?
         return self.X[idx, :self.nb_genes], self.X[idx, -3:-2], self.X[idx, -2:-1], self.X[idx, -1:]
 
     @staticmethod

--- a/scvi/log_likelihood.py
+++ b/scvi/log_likelihood.py
@@ -4,11 +4,6 @@ import torch
 
 from functions.gamma import Lgamma
 
-if torch.cuda.is_available():
-    dtype = torch.cuda.FloatTensor
-else:
-    dtype = torch.FloatTensor
-
 
 def log_zinb_positive(x, mu, theta, pi, eps=1e-8):
     """
@@ -23,9 +18,6 @@ def log_zinb_positive(x, mu, theta, pi, eps=1e-8):
     pi: logit of the dropout parameter (real support) (shape: minibatch x genes)
     eps: numerical stability constant
     """
-    # CAREFUL: MODIFICATION WITH APPROXIMATION OF THE LGAMMA FUNCTION
-    x, mu, theta, pi = x.type(dtype), mu.type(dtype), theta.type(dtype), pi.type(dtype)
-
     def softplus(x):
         return torch.log(1 + torch.exp(x))
 

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -6,13 +6,13 @@ import torch
 import torch.nn as nn
 from torch.autograd import Variable
 
-from scvi.log_likelihood import log_zinb_positive
+from scvi.log_likelihood import log_zinb_positive, log_nb_positive
 
 
 # VAE model
 class VAE(nn.Module):
     def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1,
-                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1):
+                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1, reconstruction_loss="zinb"):
         super(VAE, self).__init__()
 
         self.dropout_rate = dropout_rate
@@ -25,8 +25,9 @@ class VAE(nn.Module):
         self.dispersion = dispersion
         self.log_variational = log_variational
         self.kl_scale = kl_scale
+        self.reconstruction_loss = reconstruction_loss
         if self.dispersion == "gene":
-            self.register_buffer('px_r', torch.randn(self.n_input, ))
+            self.register_buffer('px_r', Variable(torch.randn(self.n_input, )))
 
         self.encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
                                dropout_rate=dropout_rate)
@@ -62,7 +63,10 @@ class VAE(nn.Module):
         px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sampled_batch)
 
         # Reconstruction Loss
-        reconst_loss = -log_zinb_positive(sampled_batch, px_rate, torch.exp(Variable(px_r)), px_dropout)
+        if self.reconstruction_loss == 'zinb':
+            reconst_loss = -log_zinb_positive(sampled_batch, px_rate, torch.exp(px_r), px_dropout)
+        elif self.reconstruction_loss == 'nb':
+            reconst_loss = -log_nb_positive(sampled_batch, px_rate, torch.exp(px_r))
 
         # KL Divergence
         kl_divergence_z = torch.sum(0.5 * (qz_m ** 2 + qz_v - torch.log(qz_v + 1e-8) - 1), dim=1)
@@ -70,12 +74,27 @@ class VAE(nn.Module):
             ((ql_m - local_l_mean) ** 2) / local_l_var + ql_v / local_l_var
             + torch.log(local_l_var + 1e-8) - torch.log(ql_v + 1e-8) - 1), dim=1)
 
-        kl_ponderation = Variable(kl_ponderation)
         kl_divergence = (kl_divergence_z + kl_divergence_l)
 
-        # Total Loss
-        total_loss = torch.mean(reconst_loss + kl_ponderation * kl_divergence)
-        return total_loss, reconst_loss, kl_divergence
+        # Train Loss # Not real total loss
+        train_loss = torch.mean(reconst_loss + kl_ponderation * kl_divergence)
+        return train_loss, reconst_loss, kl_divergence
+
+    def compute_log_likelihood(self, data_loader):
+        # Iterate once over the data_loader and computes the total log_likelihood
+        log_lkl = 0
+        for i_batch, (sample_batched, local_l_mean, local_l_var, batch_index) in enumerate(data_loader):
+            sample_batched = Variable(sample_batched)
+            if torch.cuda.is_available():
+                sample_batched = sample_batched.cuda()
+
+            px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sample_batched)
+            if self.reconstruction_loss == 'zinb':
+                sample_loss = -log_zinb_positive(sample_batched, px_rate, torch.exp(px_r), px_dropout)
+            elif self.reconstruction_loss == 'nb':
+                sample_loss = -log_nb_positive(sample_batched, px_rate, torch.exp(px_r))
+            log_lkl += torch.sum(sample_loss).data[0]
+        return log_lkl / len(data_loader.dataset)
 
 
 # Encoder

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -5,12 +5,14 @@
 """Tests for `scvi` package."""
 
 from run_benchmarks import run_benchmarks
-from scvi.dataset import load_dataset
+from scvi.dataset import load_datasets
 
 
 def test_benchmark():
-    run_benchmarks(load_dataset("synthetic"), n_epochs=1)
+    gene_dataset_train, gene_dataset_test = load_datasets("synthetic")
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1)
 
 
 def test_cortex():
-    run_benchmarks(load_dataset("cortex"), n_epochs=1)
+    gene_dataset_train, gene_dataset_test = load_datasets("cortex")
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1)


### PR DESCRIPTION
* add reconstruction loss as flag in VAE
* move compute log likelihood as a vae function
* change load_dataset to load_datasets for train and test dataset
* in train: now evaluating marginal log likelihood for train/test every 10 epochs
* remove remaining useless “dtype” casting and call .cuda() only for each batch

Questions:

* maybe there is a cleaner way to handle train/test in only one dataset object
* maybe .cuda() should be called in the __iter__ method of dataset ? (so as not to call it both in the train and test procedure)