### PR TITLE
Taking into account multiple batches

### DIFF
--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -24,5 +24,3 @@ if __name__ == '__main__':
     end = time.time()
     print("Total runtime for " + str(args.epochs) + " epochs is: " + str((end - start))
           + " seconds for a mean per epoch runtime of " + str((end - start) / args.epochs) + " seconds.")
-
-

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -11,7 +11,8 @@ from scvi.dataset import load_datasets
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-e", "--epochs", type=int, default=250)
-    parser.add_argument("-d", "--dataset", type=str, default="synthetic")
+    parser.add_argument("-d", "--dataset", type=str, default="cortex")
+    parser.add_argument("-b", "--use_batches", type=bool, default=True)
 
     # Might be a useful options to combine multiple datasets as an argument
     # parser.add_argument("-l", "--list", help="A list of args", nargs='+', default=[])
@@ -20,7 +21,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     gene_dataset_train, gene_dataset_test = load_datasets(args.dataset)
     start = time.time()
-    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs, use_batches=True)
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs, use_batches=args.use_batches)
     end = time.time()
     print("Total runtime for " + str(args.epochs) + " epochs is: " + str((end - start))
           + " seconds for a mean per epoch runtime of " + str((end - start) / args.epochs) + " seconds.")

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -11,7 +11,7 @@ from scvi.dataset import load_datasets
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-e", "--epochs", type=int, default=250)
-    parser.add_argument("-d", "--dataset", type=str, default="cortex")
+    parser.add_argument("-d", "--dataset", type=str, default="synthetic")
 
     # Might be a useful options to combine multiple datasets as an argument
     # parser.add_argument("-l", "--list", help="A list of args", nargs='+', default=[])
@@ -20,7 +20,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     gene_dataset_train, gene_dataset_test = load_datasets(args.dataset)
     start = time.time()
-    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs)
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs, use_batches=True)
     end = time.time()
     print("Total runtime for " + str(args.epochs) + " epochs is: " + str((end - start))
           + " seconds for a mean per epoch runtime of " + str((end - start) / args.epochs) + " seconds.")
+
+

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -34,8 +34,8 @@ def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learnin
 
     # - imputation
 
-    imputation_score = imputation(vae, gene_dataset_train)
-    print("Imputation score (MAE) is:", imputation_score)
+    imputation_train = imputation(vae, data_loader_train)
+    print("Imputation score on train (MAE) is:", imputation_train)
 
     # - batch mixing
     if gene_dataset_train.n_batches == 2:

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -7,7 +7,7 @@ from scvi.scvi import VAE
 from scvi.train import train
 
 
-def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learning_rate=1e-3):
+def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learning_rate=1e-3, use_batches=False):
     # options:
     # - gene_dataset: a GeneExpressionDataset object
     # call each of the 4 benchmarks:
@@ -20,7 +20,7 @@ def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learnin
 
     data_loader_train = DataLoader(gene_dataset_train, batch_size=128, shuffle=True, num_workers=1)
     data_loader_test = DataLoader(gene_dataset_test, batch_size=128, shuffle=True, num_workers=1)
-    vae = VAE(gene_dataset_train.nb_genes)
+    vae = VAE(gene_dataset_train.nb_genes, batch=use_batches, n_batch=gene_dataset_train.n_batches)
     if torch.cuda.is_available():
         vae.cuda()
     train(vae, data_loader_train, data_loader_test, n_epochs=n_epochs, learning_rate=learning_rate)
@@ -39,7 +39,7 @@ def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learnin
 
     # - batch mixing
     if gene_dataset_train.n_batches == 2:
-        vae(gene_dataset_train.get_all())  # Just run a forward pass on all the data
+        vae(gene_dataset_train.get_all(), gene_dataset_train.get_batches())  # Just run a forward pass on all the data
         latent = vae.z.data.numpy()
-        batches = gene_dataset_train.get_batches()
-        print("Entropy batch mixing :", entropy_batch_mixing(latent, batches))
+        batches_as_np = gene_dataset_train.get_batches_as_numpy()
+        print("Entropy batch mixing :", entropy_batch_mixing(latent, batches_as_np))

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -39,7 +39,11 @@ def run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1000, learnin
 
     # - batch mixing
     if gene_dataset_train.n_batches == 2:
-        vae(gene_dataset_train.get_all(), gene_dataset_train.get_batches())  # Just run a forward pass on all the data
-        latent = vae.z.data.numpy()
-        batches_as_np = gene_dataset_train.get_batches_as_numpy()
-        print("Entropy batch mixing :", entropy_batch_mixing(latent, batches_as_np))
+        latent = []
+        batch_indices = []
+        for sample_batch, local_l_mean, local_l_var, batch_index in data_loader_train:
+            latent += [vae.sample_from_posterior(sample_batch)]  # Just run a forward pass on all the data
+            batch_indices += [batch_index]
+        latent = torch.cat(latent)
+        batch_indices = torch.cat(batch_indices)
+        print("Entropy batch mixing :", entropy_batch_mixing(latent.data.numpy(), batch_indices.numpy()))

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -4,7 +4,6 @@
 For the moment, is initialized with a torch Tensor of size (n_cells, nb_genes)"""
 import numpy as np
 import torch
-import copy
 from torch.utils.data import Dataset
 
 
@@ -46,16 +45,6 @@ class GeneExpressionDataset(Dataset):
     def get_batches_as_numpy(self):
         dtype = torch.cuda.IntTensor if torch.cuda.is_available() else torch.IntTensor
         return self.X[:, -1:].type(dtype).numpy()
-
-    def dropout(self, rate):
-        dropout_dataset = copy.deepcopy(self)
-        indices = torch.nonzero(dropout_dataset.X[:, :-3])
-        i, j = indices[:, 0], indices[:, 1]
-
-        # choice number 1 : select 10 percent of the non zero values (so that distributions overlap enough)
-        ix = torch.LongTensor(np.random.choice(range(len(i)), int(np.floor(rate * len(i))), replace=False))
-        dropout_dataset.X[:, :-3][i[ix], j[ix]] *= 0  # *np.random.binomial(1, rate)
-        return dropout_dataset, i.numpy(), j.numpy(), ix
 
     def __len__(self):
         return self.total_size

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -4,6 +4,7 @@
 For the moment, is initialized with a torch Tensor of size (n_cells, nb_genes)"""
 import numpy as np
 import torch
+import copy
 from torch.utils.data import Dataset
 
 
@@ -40,7 +41,21 @@ class GeneExpressionDataset(Dataset):
 
     def get_batches(self):
         dtype = torch.cuda.IntTensor if torch.cuda.is_available() else torch.IntTensor
+        return self.X[:, -1:].type(dtype)
+
+    def get_batches_as_numpy(self):
+        dtype = torch.cuda.IntTensor if torch.cuda.is_available() else torch.IntTensor
         return self.X[:, -1:].type(dtype).numpy()
+
+    def dropout(self, rate):
+        dropout_dataset = copy.deepcopy(self)
+        indices = torch.nonzero(dropout_dataset.X[:, :-3])
+        i, j = indices[:, 0], indices[:, 1]
+
+        # choice number 1 : select 10 percent of the non zero values (so that distributions overlap enough)
+        ix = torch.LongTensor(np.random.choice(range(len(i)), int(np.floor(rate * len(i))), replace=False))
+        dropout_dataset.X[:, :-3][i[ix], j[ix]] *= 0  # *np.random.binomial(1, rate)
+        return dropout_dataset, i.numpy(), j.numpy(), ix
 
     def __len__(self):
         return self.total_size

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -43,8 +43,7 @@ class GeneExpressionDataset(Dataset):
         return self.X[:, -1:].type(dtype)
 
     def get_batches_as_numpy(self):
-        dtype = torch.cuda.IntTensor if torch.cuda.is_available() else torch.IntTensor
-        return self.X[:, -1:].type(dtype).numpy()
+        return self.get_batches().numpy()
 
     def __len__(self):
         return self.total_size

--- a/scvi/imputation.py
+++ b/scvi/imputation.py
@@ -1,6 +1,6 @@
 import numpy as np
-from scvi.dataset import GeneExpressionDataset
 from torch.utils.data import DataLoader
+
 
 def imputation_error(X_pred, X, i, j, ix):
     """
@@ -24,7 +24,8 @@ def imputation(vae, gene_dataset):
         X = gene_dataset.get_all().numpy()
 
     gene_dropout_dataset, i, j, ix = gene_dataset.dropout(rate=0.1)
-    data_loader_dropout = DataLoader(gene_dropout_dataset, batch_size=len(gene_dropout_dataset), shuffle=True, num_workers=1)
+    data_loader_dropout = DataLoader(gene_dropout_dataset, batch_size=len(gene_dropout_dataset),
+                                     shuffle=True, num_workers=1)
     for sample_batch, local_l_mean, local_l_var, batch_index in data_loader_dropout:
         _, _, px_rate, _, _, _, _, _ = vae(sample_batch, batch_index)
     if px_rate.data.is_cuda:

--- a/scvi/imputation.py
+++ b/scvi/imputation.py
@@ -1,35 +1,16 @@
 import numpy as np
-from torch.utils.data import DataLoader
+
+import torch
 
 
-def imputation_error(X_pred, X, i, j, ix):
-    """
-    X_pred: imputed dataset
-    X: original dataset
-    X_zero: zeros dataset
-    i, j, ix: indices of where dropout was applied
-    ========
-    returns:
-    median L1 distance between datasets at indices given
-    """
-    all_index = i[ix], j[ix]
-    x, y = X_pred[all_index], X[all_index]
-    return np.median(np.abs(x - y))
-
-
-def imputation(vae, gene_dataset):
-    if gene_dataset.get_all().is_cuda:
-        X = gene_dataset.get_all().cpu().numpy()
-    else:
-        X = gene_dataset.get_all().numpy()
-
-    gene_dropout_dataset, i, j, ix = gene_dataset.dropout(rate=0.1)
-    data_loader_dropout = DataLoader(gene_dropout_dataset, batch_size=len(gene_dropout_dataset),
-                                     shuffle=True, num_workers=1)
-    for sample_batch, local_l_mean, local_l_var, batch_index in data_loader_dropout:
-        _, _, px_rate, _, _, _, _, _ = vae(sample_batch, batch_index)
-    if px_rate.data.is_cuda:
-        mae = imputation_error(px_rate.data.cpu().numpy(), X, i, j, ix)
-    else:
-        mae = imputation_error(px_rate.data.numpy(), X, i, j, ix)
-    return mae
+def imputation(vae, data_loader, rate=0.1):
+    distance_list = torch.FloatTensor([])
+    for sample_batch, local_l_mean, local_l_var, batch_index in data_loader:
+        dropout_batch = sample_batch.clone()
+        indices = torch.nonzero(dropout_batch)
+        i, j = indices[:, 0], indices[:, 1]
+        ix = torch.LongTensor(np.random.choice(range(len(i)), int(np.floor(rate * len(i))), replace=False))
+        dropout_batch[i[ix], j[ix]] *= 0
+        _, _, px_rate, _, _, _, _, _ = vae(dropout_batch, batch_index)
+        distance_list = torch.cat([distance_list, torch.abs(px_rate[i[ix], j[ix]].data - sample_batch[i[ix], j[ix]])])
+    return torch.median(distance_list)

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -39,6 +39,13 @@ class VAE(nn.Module):
         self.decoder = Decoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
                                dropout_rate=dropout_rate, batch=batch, n_batch=n_batch)
 
+    def sample_from_posterior(self, x):
+        # Here we compute as little as possible to have q(z|x)
+        qz = self.encoder.z_encoder(x)
+        qz_m = self.encoder.z_mean_encoder(qz)
+        qz_v = torch.exp(self.encoder.z_var_encoder(qz))
+        return self.reparameterize(qz_m, qz_v)
+
     def reparameterize(self, mu, var):
         std = torch.sqrt(var)
         eps = Variable(std.data.new(std.size()).normal_())

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -12,7 +12,8 @@ from scvi.log_likelihood import log_zinb_positive, log_nb_positive
 # VAE model
 class VAE(nn.Module):
     def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1,
-                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1, reconstruction_loss="zinb",batch=False, n_batch=0):
+                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1, reconstruction_loss="zinb",
+                 batch=False, n_batch=0):
         super(VAE, self).__init__()
 
         self.dropout_rate = dropout_rate
@@ -59,11 +60,11 @@ class VAE(nn.Module):
         self.library = self.reparameterize(ql_m, ql_v)
 
         if self.dispersion == "gene-cell":
-            px_scale, self.px_r, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z,
-                                                                         self.library, batch_index)
+            px_scale, self.px_r, px_rate, px_dropout = self.decoder.forward(self.dispersion,
+                                                                            self.z, self.library, batch_index)
         elif self.dispersion == "gene":
-            px_scale, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z,
-                                                                 self.library, batch_index)
+            px_scale, px_rate, px_dropout = self.decoder.forward(self.dispersion,
+                                                                 self.z, self.library, batch_index)
 
         return px_scale, self.px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v
 
@@ -222,8 +223,8 @@ class Decoder(nn.Module):
                 batch_ind = batch_ind.type(torch.cuda.LongTensor)
             else:
                 batch_ind = batch_ind.type(torch.LongTensor)
-            onehot = torch.zeros(list(batch_index.size())[0],n_batch).type(dtype)
-            onehot[:,batch_ind] = 1
+            onehot = torch.zeros(list(batch_index.size())[0], n_batch).type(dtype)
+            onehot[:, batch_ind] = 1
             # Returns a variable hopefully with the same type as z
             return Variable(onehot)
 

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -12,7 +12,7 @@ from scvi.log_likelihood import log_zinb_positive, log_nb_positive
 # VAE model
 class VAE(nn.Module):
     def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1,
-                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1, reconstruction_loss="zinb"):
+                 dropout_rate=0.1, dispersion="gene", log_variational=True, kl_scale=1, reconstruction_loss="zinb",batch=False, n_batch=0):
         super(VAE, self).__init__()
 
         self.dropout_rate = dropout_rate
@@ -26,21 +26,29 @@ class VAE(nn.Module):
         self.log_variational = log_variational
         self.kl_scale = kl_scale
         self.reconstruction_loss = reconstruction_loss
+        self.n_batch = n_batch
+        # boolean indicating whether we want to take the batch indexes into account
+        self.batch = batch
+
         if self.dispersion == "gene":
             self.register_buffer('px_r', Variable(torch.randn(self.n_input, )))
 
         self.encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
                                dropout_rate=dropout_rate)
         self.decoder = Decoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
-                               dropout_rate=dropout_rate)
+                               dropout_rate=dropout_rate, batch=batch, n_batch=n_batch)
 
     def reparameterize(self, mu, var):
         std = torch.sqrt(var)
         eps = Variable(std.data.new(std.size()).normal_())
         return eps.mul(std).add_(mu)
 
-    def forward(self, x):
+    def forward(self, x, batch_index=None):
         # Parameters for z latent distribution
+        if self.batch and batch_index is None:
+            raise ("This VAE was trained to take batches into account:"
+                   "please provide batch indexes when running the forward pass")
+
         if self.log_variational:
             x = torch.log(1 + x)
 
@@ -49,18 +57,22 @@ class VAE(nn.Module):
         # Sampling
         self.z = self.reparameterize(qz_m, qz_v)
         self.library = self.reparameterize(ql_m, ql_v)
+
         if self.dispersion == "gene-cell":
-            px_scale, self.px_r, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z, self.library)
+            px_scale, self.px_r, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z,
+                                                                         self.library, batch_index)
         elif self.dispersion == "gene":
-            px_scale, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z, self.library)
+            px_scale, px_rate, px_dropout = self.decoder.forward(self.dispersion, self.z,
+                                                                 self.library, batch_index)
 
         return px_scale, self.px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v
 
     def sample(self, z):
         return self.px_scale_decoder(z)
 
-    def loss(self, sampled_batch, local_l_mean, local_l_var, kl_ponderation):
-        px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sampled_batch)
+    def loss(self, sampled_batch, local_l_mean, local_l_var, kl_ponderation, batch_index=None):
+
+        px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sampled_batch, batch_index)
 
         # Reconstruction Loss
         if self.reconstruction_loss == 'zinb':
@@ -87,8 +99,7 @@ class VAE(nn.Module):
             sample_batched = Variable(sample_batched)
             if torch.cuda.is_available():
                 sample_batched = sample_batched.cuda()
-
-            px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sample_batched)
+            px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sample_batched, batch_index)
             if self.reconstruction_loss == 'zinb':
                 sample_loss = -log_zinb_positive(sample_batched, px_rate, torch.exp(px_r), px_dropout)
             elif self.reconstruction_loss == 'nb':
@@ -160,7 +171,7 @@ class Encoder(nn.Module):
 
 # Decoder
 class Decoder(nn.Module):
-    def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1, dropout_rate=0.1):
+    def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1, dropout_rate=0.1, batch=False, n_batch=0):
         super(Decoder, self).__init__()
 
         self.dropout_rate = dropout_rate
@@ -168,10 +179,19 @@ class Decoder(nn.Module):
         self.n_hidden = n_hidden
         self.n_input = n_input
         self.n_layers = n_layers
+        self.n_batch = n_batch
+        self.batch = batch
+
+        if batch:
+            self.n_hidden_real = n_hidden + n_batch
+            self.n_latent_real = n_latent + n_batch
+        else:
+            self.n_hidden_real = n_hidden
+            self.n_latent_real = n_latent
 
         # There is always a first layer
         self.decoder_first_layer = nn.Sequential(
-            nn.Linear(n_latent, n_hidden),
+            nn.Linear(self.n_latent_real, n_hidden),
             nn.BatchNorm1d(n_hidden, eps=1e-3, momentum=0.99),
             nn.ReLU())
 
@@ -179,24 +199,40 @@ class Decoder(nn.Module):
         self.decoder_hidden_layers = nn.Sequential(
             collections.OrderedDict([('Layer {}'.format(i), nn.Sequential(
                 nn.Dropout(p=self.dropout_rate),
-                nn.Linear(n_hidden, n_hidden),
+                nn.Linear(self.n_hidden, n_hidden),
                 nn.BatchNorm1d(n_hidden, eps=1e-3, momentum=0.99),
                 nn.ReLU())) for i in range(1, n_layers)]))
 
         self.x_decoder = nn.Sequential(self.decoder_first_layer, self.decoder_hidden_layers)
 
         # mean gamma
-        self.px_scale_decoder = nn.Sequential(nn.Linear(self.n_hidden, self.n_input), nn.Softmax(dim=-1))
+        self.px_scale_decoder = nn.Sequential(nn.Linear(self.n_hidden_real, self.n_input), nn.Softmax(dim=-1))
 
         # dispersion: here we only deal with gene-cell dispersion case
-        self.px_r_decoder = nn.Linear(self.n_hidden, self.n_input)
+        self.px_r_decoder = nn.Linear(self.n_hidden_real, self.n_input)
 
         # dropout
-        self.px_dropout_decoder = nn.Linear(self.n_hidden, self.n_input)
+        self.px_dropout_decoder = nn.Linear(self.n_hidden_real, self.n_input)
 
-    def forward(self, dispersion, z, library):
+    def forward(self, dispersion, z, library, batch_index=None):
         # The decoder returns values for the parameters of the ZINB distribution
+
+        def one_hot(batch_ind, n_batch, dtype):
+            if batch_ind.is_cuda:
+                batch_ind = batch_ind.type(torch.cuda.LongTensor)
+            else:
+                batch_ind = batch_ind.type(torch.LongTensor)
+            onehot = torch.zeros(list(batch_index.size())[0],n_batch).type(dtype)
+            onehot[:,batch_ind] = 1
+            # Returns a variable hopefully with the same type as z
+            return Variable(onehot)
+
+        if self.batch:
+            one_hot_batch = one_hot(batch_index, self.n_batch, z.data.type())
+            z = torch.cat((z, one_hot_batch), 1)
         px = self.x_decoder(z)
+        if self.batch:
+            px = torch.cat((px, one_hot_batch), 1)
         px_scale = self.px_scale_decoder(px)
         px_dropout = self.px_dropout_decoder(px)
         px_rate = torch.exp(library) * px_scale

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -9,9 +9,11 @@ def train(vae, data_loader_train, data_loader_test, n_epochs=20, learning_rate=0
     # Training the model
     for epoch in range(n_epochs):
         for i_batch, (sample_batch, local_l_mean, local_l_var, batch_index) in enumerate(data_loader_train):
+
             sample_batch = Variable(sample_batch)
             local_l_mean = Variable(local_l_mean)
             local_l_var = Variable(local_l_var)
+
             if torch.cuda.is_available():
                 sample_batch.cuda()
                 local_l_mean.cuda()
@@ -23,9 +25,12 @@ def train(vae, data_loader_train, data_loader_test, n_epochs=20, learning_rate=0
                 kl_ponderation = kl
 
             # Train loss is actually different from the real loss due to kl_ponderation
-            train_loss, reconst_loss, kl_divergence = vae.loss(
-                sample_batch, local_l_mean, local_l_var, kl_ponderation
-            )
+            if vae.batch:
+                train_loss, reconst_loss, kl_divergence = vae.loss(
+                    sample_batch, local_l_mean, local_l_var, kl_ponderation, batch_index)
+            else:
+                train_loss, reconst_loss, kl_divergence = vae.loss(
+                    sample_batch, local_l_mean, local_l_var, kl_ponderation)
             real_loss = reconst_loss + kl_divergence
             optimizer.zero_grad()
             train_loss.backward()

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -10,7 +10,7 @@ from scvi.dataset import load_datasets
 
 def test_benchmark():
     gene_dataset_train, gene_dataset_test = load_datasets("synthetic")
-    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1)
+    run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=1, use_batches=True)
 
 
 def test_cortex():


### PR DESCRIPTION
Added the ability to use batch information in the VAE decoder. Run benchmarks on a synthetic dataset with two batches to ensure that it works fine. As the structure of the VAE (the decoder especially) depends on whether the batches are taken into account or not, running a forward pass on a VAE that was initialized with batch = True without feeding him batch_indexes for the samples will raise an error (the decoder's structure requires to concatenate z with batch_index as a one hot tensor)