### PR TITLE
store dataset as a sparse scipy matrix

### DIFF
--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -11,7 +11,7 @@ from scvi.dataset import load_datasets
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--epochs", type=int, default=250, help="how many times to process the dataset")
-    parser.add_argument("--dataset", type=str, default="brain_large", help="which dataset to process")
+    parser.add_argument("--dataset", type=str, default="cortex", help="which dataset to process")
     parser.add_argument("--nobatches", action='store_true', help="whether to ignore batches")
     parser.add_argument("--nocuda", action='store_true',
                         help="whether to use cuda (will apply only if cuda is available")
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     gene_dataset_train, gene_dataset_test = load_datasets(args.dataset)
     start = time.time()
     run_benchmarks(gene_dataset_train, gene_dataset_test, n_epochs=args.epochs,
-                   use_batches=(not args.nobatches), use_cuda=(not args.nocuda))
+                   use_batches=(not args.nobatches), use_cuda=(not args.nocuda), show_batch_mixing=True)
     end = time.time()
     print("Total runtime for " + str(args.epochs) + " epochs is: " + str((end - start))
           + " seconds for a mean per epoch runtime of " + str((end - start) / args.epochs) + " seconds.")

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -11,7 +11,7 @@ from scvi.dataset import load_datasets
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--epochs", type=int, default=250, help="how many times to process the dataset")
-    parser.add_argument("--dataset", type=str, default="cortex", help="which dataset to process")
+    parser.add_argument("--dataset", type=str, default="brain_large", help="which dataset to process")
     parser.add_argument("--nobatches", action='store_true', help="whether to ignore batches")
     parser.add_argument("--nocuda", action='store_true',
                         help="whether to use cuda (will apply only if cuda is available")

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -10,8 +10,8 @@ from scvi.dataset import load_datasets
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--epochs", type=int, default=250, help="how many times to process the dataset")
-    parser.add_argument("--dataset", type=str, default="cortex", help="which dataset to process")
+    parser.add_argument("--epochs", type=int, default=25, help="how many times to process the dataset")
+    parser.add_argument("--dataset", type=str, default="synthetic", help="which dataset to process")
     parser.add_argument("--nobatches", action='store_true', help="whether to ignore batches")
     parser.add_argument("--nocuda", action='store_true',
                         help="whether to use cuda (will apply only if cuda is available")

--- a/scvi/dataset/brain_large.py
+++ b/scvi/dataset/brain_large.py
@@ -61,7 +61,7 @@ def save_matrix_to_h5(gbm, filename, genome):
 
 
 class BrainLargeDataset(GeneExpressionDataset):
-    def __init__(self, subsample_size=20):
+    def __init__(self, subsample_size=1):
         """
         :param subsample_size: In thousands of barcodes kept (by default 1*1000=1000 kept)
         """
@@ -72,7 +72,8 @@ class BrainLargeDataset(GeneExpressionDataset):
         self.genome = "mm10"
         self.download_and_preprocess()
         h5_object = get_matrix_from_h5(self.save_path + self.final_name, self.genome)
-        super(BrainLargeDataset, self).__init__([np.array(h5_object.matrix.transpose().todense())])
+        super(BrainLargeDataset, self).__init__([h5_object.matrix.transpose().tocsr(copy=False)], sparse=True)
+        # super(BrainLargeDataset, self).__init__([h5_object.matrix.transpose()], sparse=True)
 
     def download(self):
 

--- a/scvi/dataset/brain_large.py
+++ b/scvi/dataset/brain_large.py
@@ -73,7 +73,6 @@ class BrainLargeDataset(GeneExpressionDataset):
         self.download_and_preprocess()
         h5_object = get_matrix_from_h5(self.save_path + self.final_name, self.genome)
         super(BrainLargeDataset, self).__init__([h5_object.matrix.transpose().tocsr(copy=False)], sparse=True)
-        # super(BrainLargeDataset, self).__init__([h5_object.matrix.transpose()], sparse=True)
 
     def download(self):
 

--- a/scvi/dataset/cortex.py
+++ b/scvi/dataset/cortex.py
@@ -1,7 +1,7 @@
 import csv
 import os
 import urllib.request
-
+import scipy.sparse as sp_sparse
 import numpy as np
 
 from .dataset import GeneExpressionDataset
@@ -15,7 +15,7 @@ class CortexDataset(GeneExpressionDataset):
         self.data_filename = 'expression_%s.npy' % type
         self.labels_filename = 'labels_%s.npy' % type
         self.download_and_preprocess()
-        super(CortexDataset, self).__init__([np.load(self.save_path + self.data_filename)],
+        super(CortexDataset, self).__init__([sp_sparse.csr_matrix(np.load(self.save_path + self.data_filename))],
                                             [np.load(self.save_path + self.labels_filename)])
 
     def download(self):

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -5,6 +5,7 @@ For the moment, is initialized with a torch Tensor of size (n_cells, nb_genes)""
 import numpy as np
 import torch
 from torch.utils.data import Dataset
+import scipy.sparse as sp_sparse
 
 
 class GeneExpressionDataset(Dataset):
@@ -13,11 +14,15 @@ class GeneExpressionDataset(Dataset):
     - local library size normalization (mean, var) per batch
     """
 
-    def __init__(self, Xs, list_labels=None):
+    def __init__(self, Xs, list_labels=None, sparse=False):
         # Args:
         # Xs: a list of numpy tensors with .shape[1] identical (total_size*nb_genes)
+        # or a list of scipy CSR sparse matrix,
+        # or transposed CSC sparse matrix (the argument sparse must then be set to true)
         self.nb_genes = Xs[0].shape[1]
         self.n_batches = len(Xs)
+        self.sparse = sparse
+
         assert all(X.shape[1] == self.nb_genes for X in Xs), "All tensors must have same size"
 
         new_Xs = []
@@ -25,20 +30,23 @@ class GeneExpressionDataset(Dataset):
         local_vars = []
         batch_indices = []
         for i, X in enumerate(Xs):
-            X = torch.Tensor(X)
-            log_counts = torch.log(torch.sum(X, dim=1))
+            log_counts = torch.log(torch.from_numpy(np.asarray((X.sum(axis=1)), dtype=float))
+                                   .type(torch.FloatTensor))
             local_mean = torch.mean(log_counts)
             local_var = torch.var(log_counts)
             new_Xs += [X]
-            local_means += [local_mean * torch.ones((X.size()[0], 1))]
-            local_vars += [local_var * torch.ones((X.size()[0], 1))]
-            batch_indices += [torch.LongTensor(i * np.ones((X.size()[0], 1)))]
+            local_means += [local_mean * torch.ones((X.shape[0], 1))]
+            local_vars += [local_var * torch.ones((X.shape[0], 1))]
+            batch_indices += [torch.LongTensor(i * np.ones((X.shape[0], 1)))]
 
         self.local_means = torch.cat(local_means, dim=0)
         self.local_vars = torch.cat(local_vars, dim=0)
         self.batch_indices = torch.cat(batch_indices)
-        self.X = torch.cat(new_Xs, dim=0)
-        self.total_size = self.X.size(0)
+        if self.sparse:
+            self.X = sp_sparse.vstack(new_Xs)
+        else:
+            self.X = np.vstack(new_Xs)
+        self.total_size = self.X.shape[0]
 
         all_labels = []
         if list_labels is not None:
@@ -49,13 +57,23 @@ class GeneExpressionDataset(Dataset):
             self.all_labels = torch.zeros_like(self.batch_indices)  # We might want default label values
 
     def get_all(self):
-        return self.X
+        if self.sparse:
+            return torch.Tensor(self.X.toarray())
+        else:
+            return torch.Tensor(self.X)
+
+        # return self.X
 
     def __len__(self):
         return self.total_size
 
     def __getitem__(self, idx):
-        return self.X[idx], self.local_means[idx], self.local_vars[idx], self.batch_indices[idx], self.all_labels[idx]
+        if self.sparse:
+            return torch.Tensor(np.resize(self.X[idx, :].toarray(), (self.X[idx, :].toarray().shape[1]))), \
+                   self.local_means[idx], self.local_vars[idx], self.batch_indices[idx], self.all_labels[idx]
+        else:
+            return torch.Tensor(self.X[idx]),\
+                   self.local_means[idx], self.local_vars[idx], self.batch_indices[idx], self.all_labels[idx]
 
     @staticmethod
     def train_test_split(*Xs, train_size=0.75):

--- a/scvi/dataset/synthetic.py
+++ b/scvi/dataset/synthetic.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.sparse as sp_sparse
 
 from . import GeneExpressionDataset
 
@@ -9,4 +10,4 @@ class SyntheticDataset(GeneExpressionDataset):
         data = np.random.negative_binomial(5, 0.3, size=(batch_size, nb_genes, n_batches))
         mask = np.random.binomial(n=1, p=0.7, size=(batch_size, nb_genes, n_batches))
         newdata = (data * mask).swapaxes(0, 2)  # We put the batch index first
-        super(SyntheticDataset, self).__init__(newdata)
+        super(SyntheticDataset, self).__init__([sp_sparse.csr_matrix(data) for data in newdata])

--- a/scvi/scvi.py
+++ b/scvi/scvi.py
@@ -82,7 +82,6 @@ class VAE(nn.Module):
         return self.px_scale_decoder(z)
 
     def loss(self, sampled_batch, local_l_mean, local_l_var, kl_ponderation, batch_index=None):
-
         px_scale, px_r, px_rate, px_dropout, qz_m, qz_v, ql_m, ql_v = self(sampled_batch, batch_index)
 
         # Reconstruction Loss

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -15,7 +15,6 @@ def train(vae, data_loader_train, data_loader_test, n_epochs=20, learning_rate=0
             sample_batch = Variable(sample_batch)
             local_l_mean = Variable(local_l_mean)
             local_l_var = Variable(local_l_var)
-
             if vae.using_cuda:
                 sample_batch = sample_batch.cuda(async=True)
                 local_l_mean = local_l_mean.cuda(async=True)

--- a/scvi/visualization.py
+++ b/scvi/visualization.py
@@ -1,11 +1,9 @@
 from sklearn.manifold import TSNE
-import matplotlib
 import matplotlib.pyplot as plt
 
-matplotlib.use('agg')
 
-
-def show_t_sne(latent, labels, title, cmap=plt.get_cmap("tab10", 7), return_t_sne=False):
+def show_t_sne(latent, labels, title, cmap=plt.get_cmap("tab10", 7),
+               return_t_sne=False):
     if latent.shape[1] != 2:
         latent = TSNE().fit_transform(latent)
     plt.figure(figsize=(10, 10))


### PR DESCRIPTION
The dataset class now handles both numpy arrays or scipy CSC/CSR sparse matrix. If the data is stored as a sparse matrix, the data will be densified on the fly as the get_item method or get_all method is called.

We'll check this afternoon whether using this sparse format instead of densifiying all the matrix in the beginning is faster.

closes #57 