### PR TITLE
use h5py directly to load brain_large instead of using tables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ torch==0.4
 matplotlib==2.2.2
 scikit-learn==0.19.1
 scipy==1.0.0
-tables==3.3.0
+h5py
 codecov


### PR DESCRIPTION
Before:
```
Preprocessing Brain Large data
720 genes subsampled
Preprocessing finished in : 1008 sec.
```

After:
```
Preprocessing Brain Large data
720 genes subsampled
1306127 cells subsampled
Preprocessing finished in : 218 sec.
```

@Edouard360 Please merge this PR if you don't see any problems. It seems to work fine on an aws server.